### PR TITLE
Create AWS API Gateway Integration and Modify AWS Lambda Function

### DIFF
--- a/function/main.py
+++ b/function/main.py
@@ -32,7 +32,7 @@ def ssl_cert_check_handler():
     except Exception as HostConnectionError:
         res = {
             "domain": hostname,
-            "valid": (False, HostConnectionError.args[1])
+            "is_valid": (False, HostConnectionError.args[1])
         }
     else:
         try:
@@ -45,7 +45,7 @@ def ssl_cert_check_handler():
 
             res = {
                 "domain": hostname,
-                "valid": valid,
+                "is_valid": valid,
                 "expires": expires.isoformat(),
                 "days until expiration": time_until_expiration.days,
             }

--- a/function/main.py
+++ b/function/main.py
@@ -1,9 +1,19 @@
 import datetime
 import socket
 import ssl
+import json
 
-def ssl_cert_check_handler(event, context):
-    hostname = "fearless.tech"
+
+def ssl_cert_check_handler():
+    # bad hosts
+    # hostname = "expired.badssl.com"
+    # hostname = "wrong.host.badssl.com"
+    # hostname = "self-signed.badssl.com"
+    # hostname = "untrusted-root.badssl.com"
+    # hostname = "revoked.badssl.com"
+
+    # good hosts
+    hostname = "https-everywhere.badssl.com"
 
     ssl_date_fmt = r'%b %d %H:%M:%S %Y %Z'
 
@@ -12,11 +22,38 @@ def ssl_cert_check_handler(event, context):
         socket.socket(socket.AF_INET),
         server_hostname=hostname,
     )
+
     # 3 second timeout because Lambda has runtime limitations
     conn.settimeout(3.0)
 
-    conn.connect((hostname, 443))
-    ssl_info = conn.getpeercert()
-    expires = datetime.datetime.strptime(ssl_info['notAfter'], ssl_date_fmt)
+    try:
+        # connect to a server
+        conn.connect((hostname, 443))
+    except Exception as HostConnectionError:
+        res = {
+            "domain": hostname,
+            "valid": (False, HostConnectionError.args[1])
+        }
+    else:
+        try:
+            ssl_info = conn.getpeercert()
 
-    return expires > datetime.datetime.utcnow()
+            expires = datetime.datetime.strptime(
+                ssl_info['notAfter'], ssl_date_fmt)
+            valid = expires > datetime.datetime.utcnow()
+            time_until_expiration = expires - datetime.datetime.utcnow()
+
+            res = {
+                "domain": hostname,
+                "valid": valid,
+                "expires": expires.isoformat(),
+                "days until expiration": time_until_expiration.days,
+            }
+        except Exception as e:
+            print("ssl_info error: %s" % e)
+
+    print(json.dumps(res, indent=2))
+    return json.dumps(res)
+
+
+ssl_cert_check_handler()

--- a/function/main.py
+++ b/function/main.py
@@ -52,7 +52,6 @@ def ssl_cert_check_handler():
         except Exception as GetPeerCertError:
             return ("ERROR: ", GetPeerCertError)
 
-    print(json.dumps(res, indent=2))
     return json.dumps(res)
 
 

--- a/function/main.py
+++ b/function/main.py
@@ -49,8 +49,8 @@ def ssl_cert_check_handler():
                 "expires": expires.isoformat(),
                 "days until expiration": time_until_expiration.days,
             }
-        except Exception as e:
-            print("ssl_info error: %s" % e)
+        except Exception as GetPeerCertError:
+            return ("ERROR: ", GetPeerCertError)
 
     print(json.dumps(res, indent=2))
     return json.dumps(res)

--- a/infrastructure/api_gateway.tf
+++ b/infrastructure/api_gateway.tf
@@ -1,0 +1,56 @@
+# API Gateway
+# Create API
+resource "aws_api_gateway_rest_api" "certficate_api" {
+  name        = "CertficateAPI"
+  description = "An API for validating SSL certificates."
+}
+
+# Resource - domain
+resource "aws_api_gateway_resource" "api_domain_resource" {
+  rest_api_id = aws_api_gateway_rest_api.certficate_api.id
+  parent_id   = aws_api_gateway_rest_api.certficate_api.root_resource_id
+  path_part   = "{domain}"
+}
+
+# GET Request Method
+resource "aws_api_gateway_method" "api_domain_method" {
+  rest_api_id   = aws_api_gateway_rest_api.certficate_api.id
+  resource_id   = aws_api_gateway_resource.api_domain_resource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+# Integrate API Gateway and Lambda Function
+resource "aws_api_gateway_integration" "lambda_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.certficate_api.id
+  resource_id             = aws_api_gateway_resource.api_domain_resource.id
+  http_method             = aws_api_gateway_method.api_domain_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.ssl_lambda.invoke_arn
+}
+
+# Deployment
+resource "aws_api_gateway_deployment" "certficate_api_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.certficate_api.id
+
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.api_domain_resource.id,
+      aws_api_gateway_method.api_domain_method.id,
+      aws_api_gateway_integration.lambda_integration.id,
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+}
+
+# Stage Settings for API
+resource "aws_api_gateway_stage" "certficate_api_stage" {
+  deployment_id = aws_api_gateway_deployment.certficate_api_deployment.id
+  rest_api_id   = aws_api_gateway_rest_api.certficate_api.id
+  stage_name    = "alpha"
+}

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_function" "ssl_lambda" {
   function_name    = "ssl_checker"
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "main.ssl_cert_check_handler"
-  runtime = "python3.9"
+  runtime          = "python3.9"
   source_code_hash = data.archive_file.ssl_lambda.output_base64sha256
   depends_on = [
     data.archive_file.ssl_lambda

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,0 +1,4 @@
+output "base_url" {
+  description = "Base URL for API Gateway stage."
+  value = aws_api_gateway_stage.certficate_api_stage.invoke_url
+}

--- a/solution.md
+++ b/solution.md
@@ -9,6 +9,8 @@
 
 ### Terraform
 
+1. Navigate to the infrastructure directory and follow the commands below
+
 ```sh
 terraform init
 ```
@@ -27,6 +29,10 @@ There are several ways to use this program.
 
    ```sh
    curl "$(terraform output -raw base_url)/fearless.tech"
+   ```
+
+   ```sh
+   curl "$(terraform output -raw base_url)/untrusted-root.badssl.com"
    ```
 
     `fearless.tech` can be replaced with another domain to check for its validity.

--- a/solution.md
+++ b/solution.md
@@ -1,0 +1,54 @@
+# Solution
+
+## Prerequisites
+
+- Installations: Python3, Terraform, AWS CLI
+- Permissions: AWS Credentials
+
+## Build
+
+### Terraform
+
+```sh
+terraform init
+```
+
+```sh
+terraform apply
+```
+
+## Use
+
+There are several ways to use this program.
+
+1. **Terminal or Bash Script**
+
+    Example:
+
+   ```sh
+   curl "$(terraform output -raw base_url)/fearless.tech"
+   ```
+
+    `fearless.tech` can be replaced with another domain to check for its validity.
+
+2. **On the AWS Website**
+   1. Go to the AWS website, login, and navigate to the Amazon API Gateway section. 
+   2. Click on CertficateAPI.
+   3. On the left hand menu, click stages, then alpha.
+   4. Find and click on the Invoke URL
+   5. Add a slash to the invoke URL
+   6. Enter the desired domain into the address bar
+      1. Should look like: `xyz.amazonaws.com/alpha/fearless.tech`
+
+3. **Postman or Insomnia**
+   1. Find the Invoke URL for the API.
+   2. Enter the desired domain after alpha/.
+      1. Should look like: `xyz.amazonaws.com/alpha/fearless.tech`
+   3. Click send to run the request
+
+---
+
+## Future Updates, Changes, or Outstanding Code Recommendations
+
+- Right now, the way to use the program is rather clunky. Depending on the business and project needs, I could automate running through the various domains overseen by the company using bash scripts.
+- We need to decide what we are going to do with the invalid certificates. This is a high priority item.


### PR DESCRIPTION
The main updates included are:

1. New Terraform AWS API Gateway integration
2. Python AWS Lambda function now uses try statements
4. Solution.md file outlining how to use the program

The Terraform API Gateway will build the necessary API functionality on AWS in order to be able to trigger the AWS Lambda function through a URL. A description of how to trigger the lambda function can be found in the solution.md file.

For the AWS Lambda function, I wanted to capture the error returned for an invalid certificate. Knowing the cause of an invalid certificate will allow us to reduce time investigating as well as guide further action.

Limitations:
- Unit tests for the AWS Lambda function are not included.
- The AWS Lambda function could be refactored to be cleaner.